### PR TITLE
Add git commit and branch name to log statements

### DIFF
--- a/lib/giternal/repository.rb
+++ b/lib/giternal/repository.rb
@@ -78,7 +78,11 @@ module Giternal
     def update_output(&block)
       puts "Updating #{@name}" if verbose
       block.call
-      puts " ..updated\n" if verbose
+      if verbose
+        branch = `cd #{checkout_path} && git rev-parse --abbrev-ref HEAD`.strip
+        refname = `cd #{checkout_path} && git rev-parse --short HEAD`.strip
+        puts " ..updated to #{refname} on #{branch}\n"
+      end
     end
 
     def git_ignore_self


### PR DESCRIPTION
This simple change could have saved me at least an hour trying to debug why a particular continuous build had failed - one of the dependent projects was pulling from the incorrect branch, and that took a while to track down.

Of course, add shellescape stuff to these new lines too if you accept the shellescape pull request.